### PR TITLE
Support converting rs1compatibilitydlc_p.psarc 

### DIFF
--- a/PsarcUtil/PsarcConverter.cs
+++ b/PsarcUtil/PsarcConverter.cs
@@ -384,7 +384,7 @@ namespace PsarcUtil
                                     Techniques = ConvertTechniques((NoteMaskFlag)note.NoteMask),
                                     HandFret = (sbyte)note.AnchorFretId,
                                     SlideFret = (sbyte)note.SlideTo,
-                                    ChordID = (sbyte)note.ChordId
+                                    ChordID = note.ChordId
                                 };
 
                                 if ((chordID != -1) && (chordID != songNote.ChordID))

--- a/PsarcUtil/PsarcConverter.cs
+++ b/PsarcUtil/PsarcConverter.cs
@@ -24,7 +24,7 @@ namespace PsarcUtil
 
         string destPath;
         bool convertAudio = false;
-
+        
         JsonSerializerOptions indentedSerializerOptions = new JsonSerializerOptions()
         {
             Converters ={
@@ -72,12 +72,6 @@ namespace PsarcUtil
         {
             foreach (string psarcPath in Directory.GetFiles(path, "*.psarc"))
             {
-                // This file has song entries, but no audio
-                if (Path.GetFileName(psarcPath) == "rs1compatibilitydlc_p.psarc")
-                {
-                    continue;
-                }
-
                 try
                 {
                     if (!ConvertPsarc(psarcPath))
@@ -92,6 +86,11 @@ namespace PsarcUtil
         public bool ConvertPsarc(string psarcPath)
         {
             PsarcDecoder decoder = new PsarcDecoder(psarcPath);
+
+            // This file has song entries, but audio exists in songs.psarc, which should be one directory up
+            PsarcDecoder? songsPsarcDecoder = (Path.GetFileName(psarcPath) == "rs1compatibilitydlc_p.psarc")
+                ? new PsarcDecoder(Path.Combine(Path.GetDirectoryName(psarcPath), "..", "songs.psarc"))
+                : null;
 
             if (!Directory.Exists(destPath))
             {
@@ -231,7 +230,9 @@ namespace PsarcUtil
                     Console.WriteLine("Error createing album art: " + ex.ToString());
                 }
 
-                PsarcTOCEntry bankEntry = decoder.GetTOCEntry(songEntry.SongBank);
+                PsarcTOCEntry bankEntry = songsPsarcDecoder == null
+                    ? decoder.GetTOCEntry(songEntry.SongBank)
+                    : songsPsarcDecoder.GetTOCEntry(songEntry.SongBank);
 
                 TextWriter consoleOut = Console.Out;
 
@@ -248,7 +249,11 @@ namespace PsarcUtil
                                 // Suppress Ww2ogg logging
                                 Console.SetOut(TextWriter.Null);
 
-                                decoder.WriteOgg(songEntry.SongKey, outputStream);
+                                if (songsPsarcDecoder == null) {
+                                    decoder.WriteOgg(songEntry.SongKey, outputStream, bankEntry);
+                                } else {
+                                    songsPsarcDecoder.WriteOgg(songEntry.SongKey, outputStream, bankEntry);
+                                }
 
                                 Console.SetOut(consoleOut);
                             }

--- a/PsarcUtil/PsarcDecoder.cs
+++ b/PsarcUtil/PsarcDecoder.cs
@@ -191,14 +191,16 @@ namespace PsarcUtil
 
         static string CodebookPath = Path.Combine("Ww2ogg", "Codebooks", "packed_codebooks_aoTuV_603.bin");
 
-        public void WriteOgg(string songKey, Stream outputStream)
+        public void WriteOgg(string songKey, Stream outputStream, PsarcTOCEntry? bankEntry = null)
         {
-            PsarcSongEntry songEntry = songDict[songKey];
+            if (bankEntry == null) {
+                PsarcSongEntry songEntry = songDict[songKey];
 
-            PsarcTOCEntry bankEntry = GetTOCEntry(songEntry.SongBank);
+                bankEntry = GetTOCEntry(songEntry.SongBank);
 
-            if (bankEntry == null)
-                throw new InvalidOperationException("Song key [" + songKey + "] has no song bank entry");
+                if (bankEntry == null)
+                    throw new InvalidOperationException("Song key [" + songKey + "] has no song bank entry");
+            }
 
             BkhdAsset bank = psarcFile.InflateEntry<BkhdAsset>(bankEntry);
 

--- a/Utils/ChordLister/ChordLister.csproj
+++ b/Utils/ChordLister/ChordLister.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Utils/PsarcConverter/PsarcConverter.csproj
+++ b/Utils/PsarcConverter/PsarcConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Utils/PsarcExtract/PsarcExtract.csproj
+++ b/Utils/PsarcExtract/PsarcExtract.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Utils/PsarcLister/PsarcLister.csproj
+++ b/Utils/PsarcLister/PsarcLister.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
rs1compatibilitydlc_p.psarc contains song entries, but the audio is in songs.psarc, so this adds a second decoder that reads from songs.psarc when converting rs1compatibilitydlc_p.psarc

Also updates utils targets to net8.0 to match PsarcUtil

And also removes the sbyte cast from the ChordID, as some songs have more than 127 chords and this caused array lookup exceptions for a few songs