### PR TITLE
Adds GetAlbumArtBytes()

### DIFF
--- a/PsarcUtil/PsarcDecoder.cs
+++ b/PsarcUtil/PsarcDecoder.cs
@@ -122,9 +122,9 @@ namespace PsarcUtil
             return dds;
         }
 
-        // Same TOC lookup + inflate as GetAlbumArtAsset, but stops short of DdsAsset.ReadFrom
-        // (which pulls in Pfim + System.Drawing to decode/wrap the DDS). Callers that can't
-        // depend on System.Drawing (e.g. browser-wasm) decode these raw bytes themselves.
+        // Same TOC lookup + inflate as GetAlbumArtAsset, but stops short of DdsAsset.ReadFrom,
+        // which wraps the decoded pixels in a System.Drawing Bitmap (GDI+, unsupported on
+        // browser-wasm). Callers decode these raw DDS bytes themselves, e.g. via Pfim directly.
         public byte[] GetAlbumArtBytes(string songKey, int size)
         {
             string tocName = "album_" + songKey.ToLower() + "_" + size + ".dds";

--- a/PsarcUtil/PsarcDecoder.cs
+++ b/PsarcUtil/PsarcDecoder.cs
@@ -122,6 +122,26 @@ namespace PsarcUtil
             return dds;
         }
 
+        // Same TOC lookup + inflate as GetAlbumArtAsset, but stops short of DdsAsset.ReadFrom
+        // (which pulls in Pfim + System.Drawing to decode/wrap the DDS). Callers that can't
+        // depend on System.Drawing (e.g. browser-wasm) decode these raw bytes themselves.
+        public byte[] GetAlbumArtBytes(string songKey, int size)
+        {
+            string tocName = "album_" + songKey.ToLower() + "_" + size + ".dds";
+
+            PsarcTOCEntry tocEntry = GetTOCEntry(tocName);
+
+            if (tocEntry == null)
+                return null;
+
+            using (MemoryStream memStream = new MemoryStream())
+            {
+                psarcFile.InflateEntry(tocEntry, memStream);
+
+                return memStream.ToArray();
+            }
+        }
+
         public List<Note> GetNotes(SngAsset song)
         {
             var allNotes = new List<Note>();


### PR DESCRIPTION
- PsarcDecoder.GetAlbumArtAsset() decodes album art via DdsAsset.ReadFrom(), which wraps the decoded pixels in System.Drawing.Bitmap. This is unsupported for platforms like browser WASM
- To solve this, this PR adds an alternate PsarcDecoder.GetAlbumArtBytes(). Similar to the prior method but returns raw bytes to the caller instead of a bitmap. [Example of caller decoding bytes](https://github.com/weblings/RockyRoadImport/blob/1cf612f84221c23efbd91c30c27d7cc95357c2df/SongConverter/wasm/PsarcChartCore.Wasm/Program.cs#L91) on their end.