### PR TITLE
feat: Adds GetOggBytes()

### DIFF
--- a/PsarcUtil/PsarcDecoder.cs
+++ b/PsarcUtil/PsarcDecoder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using Rocksmith2014PsarcLib.Psarc;
 using Rocksmith2014PsarcLib.Psarc.Asset;
@@ -233,6 +234,69 @@ namespace PsarcUtil
 
                 RevorbSharp.Convert(oggStream, outputStream);
             }
+        }
+
+        static byte[] embeddedCodebook;
+
+        // Loads the same codebook data as WriteOgg's CodebookPath, but from an embedded
+        // resource instead of the filesystem - browser-wasm has no working directory to
+        // resolve CodebookPath against.
+        static byte[] GetEmbeddedCodebook()
+        {
+            if (embeddedCodebook == null)
+            {
+                Assembly assembly = typeof(Wwise_RIFF_Vorbis).Assembly;
+                string resourceName = assembly.GetManifestResourceNames()
+                    .First(name => name.EndsWith("packed_codebooks_aoTuV_603.bin"));
+
+                using Stream resourceStream = assembly.GetManifestResourceStream(resourceName);
+                using MemoryStream memStream = new MemoryStream();
+                resourceStream.CopyTo(memStream);
+                embeddedCodebook = memStream.ToArray();
+            }
+
+            return embeddedCodebook;
+        }
+
+        // Same as WriteOgg, but returns the raw bytes and skips RevorbSharp.Convert - the
+        // granule positions Wwise_RIFF_Vorbis.GenerateOgg computes are already accurate, and
+        // RevorbSharp needs native ogg.dll/vorbis.dll (via OggVorbisSharp), which browser-wasm
+        // can't load.
+        public byte[] GetOggBytes(string songKey, PsarcTOCEntry? bankEntry = null)
+        {
+            if (bankEntry == null)
+            {
+                PsarcSongEntry songEntry = songDict[songKey];
+
+                bankEntry = GetTOCEntry(songEntry.SongBank);
+
+                if (bankEntry == null)
+                    throw new InvalidOperationException("Song key [" + songKey + "] has no song bank entry");
+            }
+
+            BkhdAsset bank = psarcFile.InflateEntry<BkhdAsset>(bankEntry);
+
+            uint wemID = bank.GetWemId();
+
+            PsarcTOCEntry wemEntry = GetTOCEntry(wemID + ".wem");
+
+            if (wemEntry == null)
+                throw new InvalidOperationException("Song key [" + songKey + "] has no wem file");
+
+            using MemoryStream oggStream = new MemoryStream();
+
+            using (MemoryStream inflateStream = new MemoryStream())
+            {
+                psarcFile.InflateEntry(wemEntry, inflateStream);
+
+                BinaryWriter oggWriter = new BinaryWriter(oggStream);
+
+                Wwise_RIFF_Vorbis ww = new Wwise_RIFF_Vorbis(inflateStream, GetEmbeddedCodebook(), false, false, ForcePacketFormat.NoForcePacketFormat);
+
+                ww.GenerateOgg(oggWriter);
+            }
+
+            return oggStream.ToArray();
         }
 
         void AddArrangement(PsarcTOCEntry toc)

--- a/PsarcUtil/PsarcDecoder.cs
+++ b/PsarcUtil/PsarcDecoder.cs
@@ -258,9 +258,8 @@ namespace PsarcUtil
 
         static byte[] embeddedCodebook;
 
-        // Loads the same codebook data as WriteOgg's CodebookPath, but from an embedded
-        // resource instead of the filesystem - browser-wasm has no working directory to
-        // resolve CodebookPath against.
+        // Loads the codebook from an embedded resource instead of WriteOgg()'s file path.
+        // For callers that can't resolve paths relative to a working directory.
         static byte[] GetEmbeddedCodebook()
         {
             if (embeddedCodebook == null)
@@ -278,10 +277,8 @@ namespace PsarcUtil
             return embeddedCodebook;
         }
 
-        // Same as WriteOgg, but returns the raw bytes and skips RevorbSharp.Convert - the
-        // granule positions Wwise_RIFF_Vorbis.GenerateOgg computes are already accurate, and
-        // RevorbSharp needs native ogg.dll/vorbis.dll (via OggVorbisSharp), which browser-wasm
-        // can't load.
+        // Similar to WriteOgg(), but returns raw bytes and skips RevorbSharp.Convert().
+        // Caller then needs to write bytes to an ogg file manually
         public byte[] GetOggBytes(string songKey, PsarcTOCEntry? bankEntry = null)
         {
             if (bankEntry == null)


### PR DESCRIPTION
NOTE: Relies on BNKExtractor PR's: [Ogg Granual Position](https://github.com/mikeoliphant/BnkExtractor/pull/1) and [In-Memory Codebooks](https://github.com/mikeoliphant/BnkExtractor/pull/2). If one of those PR's shouldn't land we can scrap them and this one.

- This PR adds PsarcDecoder.GetOggBytes() which skips calling RevorbSharp.Convert() and uses an embedded codebook. Those tweaks get around browser WASM's limitation of not working with the ogg dll's and not supporting filesystem reads respectively.
- Example of this being used to connect to [WASM C#](https://github.com/weblings/RockyRoadImport/blob/1cf612f84221c23efbd91c30c27d7cc95357c2df/SongConverter/wasm/PsarcChartCore.Wasm/Program.cs#L115) and then to [Typescript](https://github.com/weblings/RockyRoadImport/blob/1cf612f84221c23efbd91c30c27d7cc95357c2df/SongConverter/src/main.ts#L413) in RockyRoadImport
